### PR TITLE
Cheer Akira Update

### DIFF
--- a/relive-simulator-core/src/commonMain/kotlin/xyz/qwewqa/relive/simulator/core/presets/dress/boss/tr/tr11/TR11CheerAkira.kt
+++ b/relive-simulator-core/src/commonMain/kotlin/xyz/qwewqa/relive/simulator/core/presets/dress/boss/tr/tr11/TR11CheerAkira.kt
@@ -137,12 +137,12 @@ val tr11CheerAkiraStrategy = FixedStrategy {
         1 -> {
             +boss[ActType.Act1]
             +boss[ActType.Act3]
-            +boss[ActType.Act6]
+            +boss[ActType.Act7]
         }
         2 -> {
             +boss[ActType.Act3]
             +boss[ActType.Act3]
-            +boss[ActType.Act6]
+            +boss[ActType.Act7]
         }
         3 -> {
             +boss[ActType.ClimaxAct]


### PR DESCRIPTION
Changed Akira's Act 6 to Act 7 so that she properly buffs on turns 1 & 2 instead of poisoning.