### PR TITLE
Updated TR11 Yachiyo's Strategy

### DIFF
--- a/relive-simulator-core/src/commonMain/kotlin/xyz/qwewqa/relive/simulator/core/presets/dress/boss/tr/tr11/TR11CheerYachiyo.kt
+++ b/relive-simulator-core/src/commonMain/kotlin/xyz/qwewqa/relive/simulator/core/presets/dress/boss/tr/tr11/TR11CheerYachiyo.kt
@@ -146,7 +146,7 @@ val tr11CheerYachiyoStrategy = FixedStrategy {
         2 -> {
             +boss[ActType.Act4]
             +boss[ActType.Act6]
-            +boss[ActType.Act8]
+            +boss[ActType.Act7]
         }
         3 -> {
             +boss[ActType.Act9]


### PR DESCRIPTION
Changed the tile 6 move on turn 2 from stun to AOE attack.