### PR TITLE
Add count method to lists in complete strategies

### DIFF
--- a/relive-simulator-core/src/commonMain/kotlin/xyz/qwewqa/relive/simulator/core/stage/strategy/complete/CompleteStrategy.kt
+++ b/relive-simulator-core/src/commonMain/kotlin/xyz/qwewqa/relive/simulator/core/stage/strategy/complete/CompleteStrategy.kt
@@ -195,7 +195,7 @@ class CompleteStrategy(val script: CsScriptNode) : Strategy {
             canQueue.asCsBoolean()
         }
 
-        // Try queueing each of the acts, one at a time. Return nothing.
+        // Try queueing each of the acts, one at a time. Return a list of the queued acts.
         context.addFunction("tryQueueEach") { args ->
             requireActs(args) // check eagerly in case the loop exits early
             val alreadyQueued = queued.size
@@ -258,7 +258,7 @@ class CompleteStrategy(val script: CsScriptNode) : Strategy {
      * - `can{Name}` uses the given filter function to determine whether the
      *   action can be performed on the given act.
      * - `try{Name}` performs the action on the first of its arguments that
-    #   passes the filter, returning that act, or false if none passed.
+     *   passes the filter, returning that act, or false if none passed.
      */
     private inline fun registerCardAction(
         name: String,

--- a/relive-simulator-core/src/commonMain/kotlin/xyz/qwewqa/relive/simulator/core/stage/strategy/complete/CompleteStrategyRuntime.kt
+++ b/relive-simulator-core/src/commonMain/kotlin/xyz/qwewqa/relive/simulator/core/stage/strategy/complete/CompleteStrategyRuntime.kt
@@ -220,6 +220,10 @@ open class CsList(val value: List<CsObject>) : CsObject {
         "containsAny" -> CsFunction { args ->
             requireActs(args).any { it in value }.asCsBoolean()
         }
+        "count" -> CsFunction { args ->
+            val acts = requireActs(args)
+            value.count { it in acts }.asCsNumber()
+        }
         "size" -> CsNumber(value.size.toDouble())
         else -> null
     }


### PR DESCRIPTION
This is useful if you want to program certain strategies for larger teams, like changing your hold depending on how many good cards you have in hand.